### PR TITLE
feat: add maxDelay option, tests for maxDelay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ The response will have some additional headers:
 |------|------|---------------|-------------|
 | delay | string, number | 1 second | Base unit of time delay applied to requests. It can be expressed in milliseconds or as string in [`ms`](https://github.com/zeit/ms) format. Set to `0` to disable delaying. |
 | delayAfter | number | 5 | number of requests received during `timeWindow` before starting to delay responses. Set to `0` to disable delaying. |
+| maxDelay | string, number | Infinity | the maximum value of delay that a request has after many consecutive attempts. It is an important option for the server when it is running behind a load balancer or reverse proxy, and has a request timeout. Set to `0` to disable delaying. |
 | timeWindow | string, number | 30 seconds | The duration of the time window during which request counts are kept in memory. It can be expressed in milliseconds or as a string in [`ms`](https://github.com/zeit/ms) format. Set to `0` to disable delaying. |
 | keyGenerator | function | (req) => req.ip | Function used to generate keys to uniquely identify requests coming from the same user
 
@@ -54,7 +55,8 @@ Registering the plugin with these options:
 fastify.register(slowDownPlugin, { 
   delay: '10 seconds',
   delayAfter: 10,
-  timeWindow: '10 minutes'
+  timeWindow: '10 minutes',
+  maxDelay: '100 seconds'
 })
 ```
 
@@ -72,6 +74,7 @@ In 10 minutes the result of hitting the API will be:
 * 13th request - 30 seconds delay
 * ```...```
 * 20th request - 100 seconds delay
+* 21st request - 100 seconds delay*
 
 After 10 minutes without hitting the API the results will be: 
 
@@ -80,3 +83,5 @@ After 10 minutes without hitting the API the results will be:
 * ```...```
 * 30th request - no delay
 * 31th request - 10 seconds delay
+
+*Delay remains the same because the value of `maxDelay` option is `100 seconds`

--- a/lib/constants.js
+++ b/lib/constants.js
@@ -2,6 +2,7 @@ export const DEFAULT_OPTIONS = {
   delayAfter: 5,
   delay: '1 second',
   timeWindow: '30 seconds',
+  maxDelay: Infinity,
   keyGenerator: req => {
     return req.ip
   }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -23,12 +23,16 @@ export const calculateDelay = (requestCounter, pluginOptions) => {
     pluginOptions.delayAfter === 0 ||
     pluginOptions.delay === 0 ||
     pluginOptions.timeWindow === 0 ||
+    pluginOptions.maxDelay === 0 ||
     requestCounter <= pluginOptions.delayAfter
   ) {
     return 0
   }
-  return (
-    (requestCounter - pluginOptions.delayAfter) *
-    convertToMs(pluginOptions.delay)
+  const maxDelayMs = convertToMs(pluginOptions.maxDelay)
+  const delayMs = convertToMs(pluginOptions.delay)
+  const remainingRequests = Math.max(
+    requestCounter - pluginOptions.delayAfter,
+    0
   )
+  return Math.min(remainingRequests * delayMs, maxDelayMs)
 }

--- a/test/delay-api.test.js
+++ b/test/delay-api.test.js
@@ -7,25 +7,63 @@ import { HEADERS, DEFAULT_OPTIONS } from '../lib/constants.js'
 import { slowDownAPI } from './helpers.js'
 
 t.test('should delay the API', async t => {
-  const fastify = Fastify()
-  await fastify.register(slowDownPlugin)
-  t.teardown(() => fastify.close())
+  t.test('using default options', async t => {
+    const fastify = Fastify()
+    await fastify.register(slowDownPlugin)
+    t.teardown(() => fastify.close())
 
-  fastify.get('/', async () => 'Hello from fastify-slow-down!')
+    fastify.get('/', async () => 'Hello from fastify-slow-down!')
 
-  await slowDownAPI(DEFAULT_OPTIONS.delayAfter, () => fastify.inject('/'))
+    await slowDownAPI(DEFAULT_OPTIONS.delayAfter, () => fastify.inject('/'))
 
-  const delayMs = convertToMs(DEFAULT_OPTIONS.delay)
+    const delayMs = convertToMs(DEFAULT_OPTIONS.delay)
 
-  let response = await fastify.inject('/')
-  t.equal(response.statusCode, 200)
-  t.equal(response.headers[HEADERS.delay], delayMs)
+    let response = await fastify.inject('/')
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers[HEADERS.delay], delayMs)
 
-  response = await fastify.inject('/')
-  t.equal(response.statusCode, 200)
-  t.equal(response.headers[HEADERS.delay], 2 * delayMs)
+    response = await fastify.inject('/')
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers[HEADERS.delay], 2 * delayMs)
 
-  response = await fastify.inject('/')
-  t.equal(response.statusCode, 200)
-  t.equal(response.headers[HEADERS.delay], 3 * delayMs)
+    response = await fastify.inject('/')
+    t.equal(response.statusCode, 200)
+    t.equal(response.headers[HEADERS.delay], 3 * delayMs)
+  })
+
+  t.test(
+    'using maxDelay option, the maximum value of delay header should be maxDelay',
+    async t => {
+      const fastify = Fastify()
+      const maxDelay = '3 seconds'
+      await fastify.register(slowDownPlugin, { maxDelay })
+      t.teardown(() => fastify.close())
+
+      fastify.get('/', async () => 'Hello from fastify-slow-down!')
+
+      await slowDownAPI(DEFAULT_OPTIONS.delayAfter, () => fastify.inject('/'))
+
+      const delayMs = convertToMs(DEFAULT_OPTIONS.delay)
+
+      let response = await fastify.inject('/')
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers[HEADERS.delay], delayMs)
+
+      response = await fastify.inject('/')
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers[HEADERS.delay], 2 * delayMs)
+
+      response = await fastify.inject('/')
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers[HEADERS.delay], 3 * delayMs)
+
+      response = await fastify.inject('/')
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers[HEADERS.delay], convertToMs(maxDelay))
+
+      response = await fastify.inject('/')
+      t.equal(response.statusCode, 200)
+      t.equal(response.headers[HEADERS.delay], convertToMs(maxDelay))
+    }
+  )
 })

--- a/test/disabled-options.test.js
+++ b/test/disabled-options.test.js
@@ -50,4 +50,19 @@ t.test('should not apply the delay header', async t => {
 
     t.equal(response.headers[HEADERS.delay], undefined)
   })
+
+  t.test('if maxDelay option is 0', async t => {
+    const fastify = Fastify()
+    await fastify.register(slowDownPlugin, {
+      maxDelay: 0
+    })
+    t.teardown(() => fastify.close())
+
+    fastify.get('/', async () => 'Hello from fastify-slow-down!')
+
+    await slowDownAPI(DEFAULT_OPTIONS.delayAfter, () => fastify.inject('/'))
+    const response = await fastify.inject('/')
+
+    t.equal(response.headers[HEADERS.delay], undefined)
+  })
 })


### PR DESCRIPTION
Add `maxDelay` option for the maximum value of delay that a request has after many consecutive attempts
Issue: [#5](https://github.com/nearform/fastify-slow-down/issues/5)