### PR TITLE
fix: inaccurate headers

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,22 +40,6 @@ const slowDownPlugin = async (fastify, settings) => {
       remaining: remainingRequests
     }
 
-    if (options.skipFailedRequests) {
-      onFinished(reply.raw, err => {
-        if (err || reply.statusCode >= 400) {
-          store.decrementOnKey(key)
-        }
-      })
-    }
-
-    if (options.skipSuccessfulRequests) {
-      onFinished(reply.raw, err => {
-        if (!err && reply.statusCode < 400) {
-          store.decrementOnKey(key)
-        }
-      })
-    }
-
     if (!hasDelay) {
       return
     }
@@ -81,6 +65,27 @@ const slowDownPlugin = async (fastify, settings) => {
     if (promiseResult === 'requestFinished') {
       reply.send('')
       return reply
+    }
+  })
+
+  fastify.addHook('onSend', async (req, reply) => {
+    const key = options.keyGenerator(req)
+    if (options.skipFailedRequests) {
+      if (reply.statusCode >= 400) {
+        await store.decrementOnKey(key)
+        if (options.headers && req.slowDown.remaining < options.delayAfter) {
+          reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
+        }
+      }
+    }
+
+    if (options.skipSuccessfulRequests) {
+      if (reply.statusCode < 400) {
+        await store.decrementOnKey(key)
+        if (options.headers && req.slowDown.remaining < options.delayAfter) {
+          reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
+        }
+      }
     }
   })
 }

--- a/index.js
+++ b/index.js
@@ -70,21 +70,17 @@ const slowDownPlugin = async (fastify, settings) => {
 
   fastify.addHook('onSend', async (req, reply) => {
     const key = options.keyGenerator(req)
-    if (options.skipFailedRequests) {
-      if (reply.statusCode >= 400) {
-        await store.decrementOnKey(key)
-        if (options.headers && req.slowDown.remaining < options.delayAfter) {
-          reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
-        }
+    if (options.skipFailedRequests && reply.statusCode >= 400) {
+      await store.decrementOnKey(key)
+      if (options.headers && req.slowDown.remaining < options.delayAfter) {
+        reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
       }
     }
 
-    if (options.skipSuccessfulRequests) {
-      if (reply.statusCode < 400) {
-        await store.decrementOnKey(key)
-        if (options.headers && req.slowDown.remaining < options.delayAfter) {
-          reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
-        }
+    if (options.skipSuccessfulRequests && reply.statusCode < 400) {
+      await store.decrementOnKey(key)
+      if (options.headers && req.slowDown.remaining < options.delayAfter) {
+        reply.header(HEADERS.remaining, req.slowDown.remaining + 1)
       }
     }
   })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "lint": "eslint .",
     "run:example": "node example/basic.js",
     "test": "npm run test:unit && npm run test:types",
-    "test:unit": "c8 --100 tap --jobs=3 --no-coverage test/*.test.js",
+    "test:unit": "c8 --100 tap --jobs=2 --no-coverage test/*.test.js",
     "test:types": "tsd",
     "prepare": "husky install"
   },

--- a/test/skip-options.test.js
+++ b/test/skip-options.test.js
@@ -114,8 +114,6 @@ t.test('should not apply the delay header', async t => {
       test.counter++
       const response = await internalFetch(port, '/')
 
-      console.log(response.headers.get([HEADERS.remaining]))
-
       t.equal(response.status, 200)
       t.equal(response.headers.get([HEADERS.delay]), null)
       t.equal(


### PR DESCRIPTION
Closes #29
We're delaying setting the `remaining` header value till `onSend` hook is called and after the store decrements value for the specific key.